### PR TITLE
Fix error when response does not have a content-type header

### DIFF
--- a/lib/execute/api.js
+++ b/lib/execute/api.js
@@ -292,18 +292,20 @@ var getApiRuntimeInfo = function (swaggerSpec, urlObj, options, update, callback
       if (swaggerSpec.paths[apiPath][pathMethod] == null) {
         swaggerSpec.paths[apiPath][pathMethod] = {};
       }
-      swaggerSpec.paths[apiPath][pathMethod]["produces"] = new Array();
-      swaggerSpec.paths[apiPath][pathMethod]["produces"].push(response.headers['content-type']);
       swaggerSpec.paths[apiPath][pathMethod]["responses"] = {};
       swaggerSpec.paths[apiPath][pathMethod]["responses"][response.statusCode] = {};
       swaggerSpec.paths[apiPath][pathMethod]["responses"][response.statusCode].description = HTTPStatus[response.statusCode];
-      if (response.headers['content-type'].indexOf('application/json') > -1 && body != '') {
-        var schemaObj = jsonSchemaGenerator(JSON.parse(body));
-        delete schemaObj.$schema;
-        // bug with json scheme generator - work around
-        // For more details, https://github.com/krg7880/json-schema-generator/issues/13
-        scan(schemaObj);
-        swaggerSpec.paths[apiPath][pathMethod]["responses"][response.statusCode].schema = schemaObj;
+      swaggerSpec.paths[apiPath][pathMethod]["produces"] = new Array();
+      if (response.headers['content-type']) {
+        swaggerSpec.paths[apiPath][pathMethod]["produces"].push(response.headers['content-type']);
+        if (response.headers['content-type'].indexOf('application/json') > -1 && body != '') {
+          var schemaObj = jsonSchemaGenerator(JSON.parse(body));
+          delete schemaObj.$schema;
+          // bug with json scheme generator - work around
+          // For more details, https://github.com/krg7880/json-schema-generator/issues/13
+          scan(schemaObj);
+          swaggerSpec.paths[apiPath][pathMethod]["responses"][response.statusCode].schema = schemaObj;
+        }
       }
       swaggerSpec.paths[apiPath][pathMethod].security = new Array();
       if (response.request.headers.authorization && response.request.headers.authorization.startsWith('Basic')) {


### PR DESCRIPTION
Fixes #5 by checking for an undefined content-type header in the response before accessing it.