### PR TITLE
Support media types which use the +json suffix

### DIFF
--- a/lib/execute/api.js
+++ b/lib/execute/api.js
@@ -406,10 +406,6 @@ var getBodyInfo = function (swaggerSpec, urlObj, options, callback) {
         var split = options.headers[i].split(':');
         headerKeyValues[split[0].trim().toLowerCase()] = split[1].trim();
       }
-      if (!headerKeyValues['content-type']) {
-        // Swagger assumes a content-type of application/json if none is supplied.
-        headerKeyValues['content-type'] = 'application/json';
-      }
       if (swaggerSpec.paths[apiPath][pathMethod]['consumes'] == null) {
         swaggerSpec.paths[apiPath][pathMethod]['consumes'] = new Array();
       }

--- a/lib/execute/api.js
+++ b/lib/execute/api.js
@@ -297,7 +297,7 @@ var getApiRuntimeInfo = function (swaggerSpec, urlObj, options, update, callback
       swaggerSpec.paths[apiPath][pathMethod]["responses"] = {};
       swaggerSpec.paths[apiPath][pathMethod]["responses"][response.statusCode] = {};
       swaggerSpec.paths[apiPath][pathMethod]["responses"][response.statusCode].description = HTTPStatus[response.statusCode];
-      if (response.headers['content-type'].indexOf('application/json') > -1 && body != '') {
+      if ((response.headers['content-type'].indexOf('application/json') > -1 || response.headers['content-type'].indexOf('+json') > -1) && body != '') {
         var schemaObj = jsonSchemaGenerator(JSON.parse(body));
         delete schemaObj.$schema;
         // bug with json scheme generator - work around
@@ -404,9 +404,19 @@ var getBodyInfo = function (swaggerSpec, urlObj, options, callback) {
       var headerKeyValues = {};
       for (var i = 0; i < options.headers.length; i++) {
         var split = options.headers[i].split(':');
-        headerKeyValues[split[0].trim()] = split[1].trim();
+        headerKeyValues[split[0].trim().toLowerCase()] = split[1].trim();
       }
-      if (headerKeyValues['Content-Type'].indexOf('application/json') > -1 || headerKeyValues['content-type'].indexOf('application/json') > -1) {
+      if (!headerKeyValues['content-type']) {
+        // Swagger assumes a content-type of application/json if none is supplied.
+        headerKeyValues['content-type'] = 'application/json';
+      }
+      if (swaggerSpec.paths[apiPath][pathMethod]['consumes'] == null) {
+        swaggerSpec.paths[apiPath][pathMethod]['consumes'] = new Array();
+      }
+      if (swaggerSpec.paths[apiPath][pathMethod]['consumes'].indexOf(headerKeyValues['content-type']) == -1) {
+        swaggerSpec.paths[apiPath][pathMethod]['consumes'].push(headerKeyValues['content-type']);
+      }
+      if (headerKeyValues['content-type'].indexOf('application/json') > -1 || headerKeyValues['content-type'].indexOf('+json') > -1) {
         // Found JSON
         var schemaObj = jsonSchemaGenerator(JSON.parse(options.data));
         delete schemaObj.$schema;
@@ -419,7 +429,7 @@ var getBodyInfo = function (swaggerSpec, urlObj, options, callback) {
           callback(null, true);
         });
       }
-      else if (headerKeyValues['Content-Type'] == 'application/x-www-form-urlencoded') {
+      else if (headerKeyValues['content-type'] == 'application/x-www-form-urlencoded') {
         if (options.data.split("&").length > 0) {
           var formParams = options.data.split("&");
           async.eachSeries(formParams, function iterator(formParam, qcallback) {


### PR DESCRIPTION
Added support for json-like media types that use the [+json](https://tools.ietf.org/html/rfc6839#section-3.1) suffix, such as `application/problem+json` or `application/hal+json`.

* Schemas are now generated for request and response bodies when the content type includes "+json"
* A `consumes` section containing the content-type of the request body is added to the Swagger output
* Fixed potential issues due to casing of keys in headerKeyValues

I originally tried to handle the case where no content-type header was included along with a request body, but the change was too out of scope. #8 was created to address it.